### PR TITLE
"Fix" vehicle part oozle uses undefined fuel oozle

### DIFF
--- a/blob/blaze_blob_parts.json
+++ b/blob/blaze_blob_parts.json
@@ -514,7 +514,7 @@
     "broken_color" : "light_red",
     "power" : 100,
     "epower" : 20,
-    "fuel_type" : "bfeed",
+    "fuel_type" : "slime_scrap",
     "item" : "oozle",
     "location" : "center",
     "flags" : ["REACTOR", "OBSTACLE"]


### PR DESCRIPTION
I compared against the old (about a year old) version of blazemod and the version on github to get an idea of overall changes.  I don't know why bfeed recipes/corpse feeding was removed but followed the concept of changes I saw and made vehicle_part id oozle use fuel_type slime_scrap.

Error in log is gone.

It seems as if the item id bfeed has largely been eliminated as none of the recipes/constructions are present and it would *appear* that any lingering bfeed objects are transformed into meat.